### PR TITLE
Remove setLeagues

### DIFF
--- a/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
+++ b/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
@@ -151,15 +151,9 @@ class SoccerAPIController extends BaseController
         $soccerAPI = new SoccerAPI();
         $include = 'league,localTeam,visitorTeam';
 
-        if ($request->query('leagues') == 'all') {
-            $leagues = '';
-        } else {
-            $leagues = $request->query('leagues', '');
-        }
-
         switch($type) {
             case('today'):
-                $livescores = $soccerAPI->livescores()->setInclude($include)->setLeagues($leagues)->today();
+                $livescores = $soccerAPI->livescores()->setInclude($include)->today();
 
                 usort($livescores, function ($a, $b) {
                     if ($a->league_id == $b->league_id) {
@@ -176,7 +170,7 @@ class SoccerAPIController extends BaseController
                 return view('livescores/livescores_today', ['livescores' => $livescores, 'date_format' => $date_format]);
                 break;
             case('now'):
-                $livescores = $soccerAPI->livescores()->setInclude($include)->setLeagues($leagues)->now();
+                $livescores = $soccerAPI->livescores()->setInclude($include)->now();
 
                 usort($livescores, function ($a, $b) {
                     if ($a->league_id == $b->league_id) {
@@ -230,16 +224,11 @@ class SoccerAPIController extends BaseController
 
         $date = self::getDateFromRequest($request);
 
-        if ($request->query('leagues') == 'all') {
-            $leagues = '';
-        } else {
-            $leagues = $request->query('leagues', '');
-        }
         $soccerAPI = new SoccerAPI();
         $include = 'league,localTeam,visitorTeam';
 
         /** @var Carbon $date */
-        $fixtures = $soccerAPI->fixtures()->setInclude($include)->setLeagues($leagues)->byDate($date);
+        $fixtures = $soccerAPI->fixtures()->setInclude($include)->byDate($date);
 
         usort($fixtures, function ($a, $b) {
             if ($a->league_id == $b->league_id) {
@@ -414,7 +403,7 @@ class SoccerAPIController extends BaseController
         } else {
             return Carbon::now()->toDateString();
         }
-        
+
         return '';
     }
 }


### PR DESCRIPTION
# Remove setLeagues method usage

This PR removes the setLeagues method that was being used on the SoccerAPIClient objects. After inspecting the API docs I didn't find any trace of this method, so it seems it was deprecated. I also didn't find a method that could be used as replacement. So for now I think it's best to remove the use of this method. 

### Please tell us , the type of Change you are submiting:
Select one of the following: 

- [ X ] Bug
- [ ] Feature
- [ ] Minor Change

```
Call to undefined method Sportmonks\SoccerAPI\Requests\LiveScore::setLeagues()
```

### Does it fix an existing issue? Please tell us which one

Fixes issue #25 

### Description of what's been changed

Use of the method `setLeagues` was removed from the SoccerAPIController


